### PR TITLE
Updated code for v0.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,10 +159,11 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-sandbox.ipynb
+*.ipynb
 sandbox.py
 *.lss
 *.json
 *.xlsx
 test.csv
 Makefile
+splits/

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,16 @@ from livesplit_parser import LivesplitData
 your_run = LivesplitData('path/to/your/Livesplit/file')
 ```
 
+Optionally, you can specify whether you want to pull `RealTime` or `GameTime` out of your splits by passing in the parameter `time_key` into the constructor. The default value for `time_key` is `time_key=RealTime`. As such, if you want to load in `GameTime` for your splits, your code would look like the following:
+
+```python
+from livesplit_parser import LivesplitData
+
+your_run = LivesplitData('path/to/your/Livesplit/file', time_key='GameTime')
+```
+
+Passing in anything other than `RealTime` or `GameTime` into `time_key` will result in a `ValueError`.
+
 These are the following private member variables you have access to with every `LivesplitData` object:
 
 * `LivesplitData.name -> str`: the name of the splits. This is just pulled from the file name.
@@ -49,6 +59,15 @@ These are the following private member variables you have access to with every `
   * `MedianSegmentSplitTime`: the **split times** for your median segments if your median segments were a completed run
   * `NumRunsPassed`: The number of attempts that completed that split
   * `PercentRunsPassed`: The percentage of attempts that completed that split
+* `LivesplitData.game_name`: The name of the game being speedran according to the splits
+* `LivesplitData.game_icon`: The game icon saved to the splits
+* `LivesplitData.category_name`: the name of the category being run
+* `LivesplitData.layout_path`: the layout path used for the splits
+* `LivesplitData.platform_name`: the name of the platform the speedruns were attempted on
+* `LivesplitData.platform_uses_emulator`: is `True` if the runs were done using an emulator, is `False` otherwise
+* `LivesplitData.offset`: the offset used by the splits
+* `LivesplitData.version`: the game version being run on
+* `LivesplitData.variables`: these are the category variables, which will appear assuming speedrun.com has them for the given category
 
 From here, you can use the other included functions (listed below) to get some plots about the data within your Livesplit file.
 

--- a/livesplit_parser/livesplit_parser.py
+++ b/livesplit_parser/livesplit_parser.py
@@ -27,6 +27,7 @@ class LivesplitData:
         self.game_name = xml_dict.get('GameName')
         self.game_icon = xml_dict.get('GameIcon')
         self.category_name = xml_dict.get('CategoryName')
+        self.layout_path = xml_dict.get('LayoutPath')
         self.platform_name = platform.get('#text')
         self.platform_uses_emulator = {'False': False, 'True': True}.get(platform.get('@usesEmulator'))
         self.offset = xml_dict.get('Offset')

--- a/livesplit_parser/livesplit_parser.py
+++ b/livesplit_parser/livesplit_parser.py
@@ -22,7 +22,9 @@ class LivesplitData:
         self.split_info_df = self.__add_float_seconds_cols(self.split_info_df, ['PersonalBest', 'BestSegment', 'Average', 'Median'])
 
         # Optional metadata
-        platform = xml_dict.get('Metadata', {}).get('Platform', {})
+        metadata: dict = xml_dict.get('Metadata', {})
+        platform: dict = metadata.get('Platform', {})
+        variables: list = metadata.get('Variables', {}).get('Variable', [])
         
         self.game_name = xml_dict.get('GameName')
         self.game_icon = xml_dict.get('GameIcon')
@@ -31,6 +33,14 @@ class LivesplitData:
         self.platform_uses_emulator = {'False': False, 'True': True}.get(platform.get('@usesEmulator'))
         self.offset = xml_dict.get('Offset')
         self.version = xml_dict.get('@version')
+
+        # Category Variables. They appear when speedrun.com has them
+        self.variables = {}
+
+        for variable in variables:
+            name = variable.get('@name')
+            text = variable.get('#text')
+            self.variables[name] = text
 
     def export_data(self):
         # Specify the Excel file path

--- a/livesplit_parser/livesplit_parser.py
+++ b/livesplit_parser/livesplit_parser.py
@@ -273,10 +273,12 @@ class LivesplitData:
 
         # now create an empty DataFrame
         segment_history_df = pd.DataFrame(index=idx, columns=col_names)
-        segment_history_df
 
         for d in data['Segments']['Segment']:
             seg_name = d['Name']
+
+            if not d['SegmentHistory']:
+                continue
 
             for t in d['SegmentHistory']['Time']:
                 # print(t)

--- a/livesplit_parser/livesplit_parser.py
+++ b/livesplit_parser/livesplit_parser.py
@@ -374,7 +374,7 @@ class LivesplitData:
 
         for i in segment_info_df.index:
             for c in cols:
-                if not pd.isna(segment_info_df[c][i]):
+                if not pd.isna(segment_info_df[c][i]) and segment_info_df[c][i] != 'NaT':
                     segment_info_df.loc[i, c] = round_time(segment_info_df[c][i])
 
         def compute_split_times(df, col_name):

--- a/livesplit_parser/livesplit_parser.py
+++ b/livesplit_parser/livesplit_parser.py
@@ -316,7 +316,10 @@ class LivesplitData:
         best_seg = []
 
         for i in segment_info_df.index:
-            best_seg.append(segment_info_df['BestSegmentTime'][i]['RealTime'])
+            if segment_info_df['BestSegmentTime'][i]:
+                best_seg.append(segment_info_df['BestSegmentTime'][i]['RealTime'])
+            else:
+                best_seg.append(np.nan)
 
         segment_info_df['BestSegment'] = best_seg
 

--- a/livesplit_parser/livesplit_parser.py
+++ b/livesplit_parser/livesplit_parser.py
@@ -28,7 +28,7 @@ class LivesplitData:
         self.game_icon = xml_dict.get('GameIcon')
         self.category_name = xml_dict.get('CategoryName')
         self.platform_name = platform.get('#text')
-        self.platform_uses_emulator = platform.get('@usesEmulator')
+        self.platform_uses_emulator = {'False': False, 'True': True}.get(platform.get('@usesEmulator'))
         self.offset = xml_dict.get('Offset')
         self.version = xml_dict.get('@version')
 

--- a/livesplit_parser/livesplit_parser.py
+++ b/livesplit_parser/livesplit_parser.py
@@ -21,6 +21,17 @@ class LivesplitData:
         self.split_info_df = self.__parse_segment_data(xml_dict, self.attempt_info_df)
         self.split_info_df = self.__add_float_seconds_cols(self.split_info_df, ['PersonalBest', 'BestSegment', 'Average', 'Median'])
 
+        # Optional metadata
+        platform = xml_dict.get('Metadata', {}).get('Platform', {})
+        
+        self.game_name = xml_dict.get('GameName')
+        self.game_icon = xml_dict.get('GameIcon')
+        self.category_name = xml_dict.get('CategoryName')
+        self.platform_name = platform.get('#text')
+        self.platform_uses_emulator = platform.get('@usesEmulator')
+        self.offset = xml_dict.get('Offset')
+        self.version = xml_dict.get('@version')
+
     def export_data(self):
         # Specify the Excel file path
         excel_file_path = f'{self.name}.xlsx'


### PR DESCRIPTION
Includes the following changes:

* Added support for blank splits 
* Added support for reading `GameTime` from splits instead of from `RealTime`
* Added access to metadata from splits, including category, platform, offset, and more

v0.2.2 released thanks to the contributions of @BrainStone 